### PR TITLE
feat: draft of interceptors for Shopify cart

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -16,12 +16,11 @@ export async function fetchProductsPreorderState(handle: string) {
   return undefined;
 }
 
-export enum NewEndpointPreorderState {
-  NoOpenWaitlists = "NO_OPEN_WAITLISTS",
-  AvailableInStock = "AVAILABLE_IN_STOCK",
-  OnPreorder = "ON_PREORDER",
-  SoldOut = "SOLD_OUT",
-}
+export type NewEndpointPreorderState =
+  | "NO_OPEN_WAITLISTS"
+  | "AVAILABLE_IN_STOCK"
+  | "ON_PREORDER"
+  | "SOLD_OUT";
 
 export interface VariantPreorderState {
   state: NewEndpointPreorderState;

--- a/src/cart.ts
+++ b/src/cart.ts
@@ -1,0 +1,23 @@
+export type ShipDates = {
+  earliest: Date;
+  latest: Date;
+};
+
+export type PreorderAttributes = {
+  releaseId: string;
+  displayShipDates: string;
+};
+
+export type CartItem = { variantId: string };
+
+export interface Cart<T extends CartItem> {
+  hasPreorderAttributes: (item: T) => boolean;
+  addPreorderAttributes: (item: T, attrs: PreorderAttributes) => T;
+  removePreorderAttributes: (item: T) => T;
+
+  // Queries
+  fetchItems: () => Promise<Required<T>[]>;
+
+  // Mutations
+  decrementQuantity: (id: string) => Promise<void>;
+}

--- a/src/interceptors.ts
+++ b/src/interceptors.ts
@@ -1,5 +1,5 @@
 export type FetchParams = [input: string | URL, init?: RequestInit];
-type JSONObject = { [key: string]: unknown };
+export type JSONObject = { [key: string]: unknown };
 
 type InterceptHandler<A> = (
   request: A,
@@ -201,7 +201,7 @@ export class RequestInterceptor extends Interceptor<Callback> {
   }
 }
 
-export function parseRequestBody(
+export function parseFetchRequestBody(
   init: RequestInit,
 ): FormData | URLSearchParams | JSONObject {
   if (typeof init.body === "string") {
@@ -233,9 +233,9 @@ export function parseRequestBody(
   throw new TypeError("request body could not be parsed");
 }
 
-export function makeRequestBody(
+export function makeFetchRequestBody(
   init: RequestInit,
-  body: ReturnType<typeof parseRequestBody>,
+  body: ReturnType<typeof parseFetchRequestBody>,
 ): URLSearchParams | FormData | string {
   if (typeof init.body === "string" && typeof body !== "string") {
     if (body instanceof URLSearchParams || body instanceof FormData) {

--- a/src/shopify-cart-interceptor.ts
+++ b/src/shopify-cart-interceptor.ts
@@ -1,0 +1,246 @@
+import {
+  JSONObject,
+  RequestInterceptor,
+  makeFetchRequestBody,
+  parseFetchRequestBody,
+  shopifyUrlStartsWith,
+} from "./interceptors";
+import ShopifyCart, {
+  ShopifyCartItem,
+  updatePreorderAttributes,
+} from "./shopify-cart";
+
+function shouldIntercept(input: string | URL) {
+  return shopifyUrlStartsWith(input, "cart/add");
+}
+
+export class ShopifyCartAddInterceptor extends RequestInterceptor {
+  constructor() {
+    super(shouldIntercept);
+
+    this.addHandler(onAddToCart);
+  }
+}
+
+async function onAddToCart([input, init]: [
+  input: string | URL,
+  init?: RequestInit,
+]): Promise<[input: string | URL, init?: RequestInit]> {
+  if (!init || !init?.body) {
+    return [input, init];
+  }
+
+  if (init.method?.toUpperCase() === "POST" || init.body) {
+    let requestBody: ReturnType<typeof parseFetchRequestBody>;
+
+    try {
+      requestBody = parseFetchRequestBody(init);
+    } catch (err) {
+      // Unsupported body type, oh dear.
+      return [input, init];
+    }
+
+    // Convert the Shopify add to cart request to our Cart API format.
+    const newItems = getItemsFromRequest(requestBody);
+
+    // Keep track of if we find anything that needs changing so we can avoid changing things that don't need it.
+    let changed = false;
+
+    const updatedItems: ShopifyCartItem[] = [];
+    for (const item of newItems) {
+      const updatedItem = await updatePreorderAttributes(item);
+      if (updatedItem) {
+        updatedItems.push(updatedItem);
+        changed = true;
+      } else {
+        updatedItems.push(item);
+      }
+    }
+
+    // If we didn't alter anything, just return the original data.
+    if (!changed) {
+      return [input, init];
+    }
+
+    // Try to convert it back to the same kind of request we started with.
+    let newBody: FormData | URLSearchParams | JSONObject = requestBody;
+
+    if ("items" in requestBody) {
+      newBody = shopifyAJAXAddToCart(updatedItems);
+    } else {
+      if (newItems.length > 1) {
+        console.error(
+          "Purple Dot: Only a single item can be added to the cart at a time when using /cart/add",
+          { request: [input, init], newItems },
+        );
+        return [input, init];
+      }
+
+      newBody = shopifyFormAddToCart(updatedItems);
+    }
+
+    return [input, { ...init, body: makeFetchRequestBody(init, newBody) }];
+  }
+
+  if (init.method?.toUpperCase() === "GET") {
+    const newURL = new URL(input);
+
+    // Convert the Shopify add to cart request to our Cart API format.
+    const newItems = getItemsFromRequest(newURL.searchParams);
+    if (newItems.length > 1) {
+      console.error(
+        "Purple Dot: Only a single item can be added to the cart at a time when using GET.",
+        { request: [input, init], newItems },
+      );
+      return [input, init];
+    }
+
+    const updatedItem = await updatePreorderAttributes(newItems[0]);
+    if (updatedItem) {
+      applyURLEncodedAddToCart(updatedItem, newURL.searchParams);
+    }
+
+    return [newURL, init];
+  }
+
+  return [input, init];
+}
+
+function getItemsFromRequest(
+  data: FormData | URLSearchParams | JSONObject,
+): ShopifyCartItem[] {
+  // Fix the documented /cart/add.js API
+  // https://shopify.dev/api/ajax/reference/cart
+
+  if ("items" in data) {
+    const pdAddToCartRequests: ShopifyCartItem[] = [];
+
+    const items = data["items"];
+
+    if (Array.isArray(items)) {
+      for (const item of items) {
+        pdAddToCartRequests.push({
+          variantId: `${item.id}`,
+          quantity: parseFloat(item.quantity ?? "1"),
+          properties: item.properties ?? {},
+        });
+      }
+    }
+
+    return pdAddToCartRequests;
+  }
+
+  // Fix the form style /cart/add API
+  const variantId = getValue(data, "id");
+  if (!variantId) {
+    return [];
+  }
+
+  const quantityValue = getValue(data, "quantity");
+  const quantity = parseFloat(quantityValue ?? "1");
+
+  const properties = extractAddToCartProperties(data);
+
+  const pdRequests: ShopifyCartItem[] = [
+    {
+      variantId,
+      quantity,
+      properties,
+    },
+  ];
+
+  return pdRequests;
+}
+
+function getValue(
+  data: FormData | URLSearchParams | JSONObject,
+  key: string,
+): string | undefined {
+  if (data instanceof FormData || data instanceof URLSearchParams) {
+    return data.get(key)?.toString();
+  } else if (key in data && data[key]) {
+    return data[key]?.toString() as string;
+  }
+}
+
+function shopifyAJAXAddToCart(request: ShopifyCartItem[]) {
+  const items = request.map((item) => {
+    return {
+      id: item.id,
+      quantity: item.quantity,
+      properties: item.properties,
+    };
+  });
+
+  return {
+    items,
+  };
+}
+
+function shopifyFormAddToCart(request: ShopifyCartItem[]) {
+  // Convert to a /cart/add request
+  const newBody = new URLSearchParams();
+
+  for (const item of request) {
+    newBody.append("id", item.variantId.toString());
+    newBody.append("quantity", item.quantity?.toString() ?? "1");
+
+    for (const [key, value] of Object.entries(item.properties ?? {})) {
+      newBody.append(`properties[${key}]`, value);
+    }
+  }
+
+  return newBody;
+}
+
+function applyURLEncodedAddToCart(
+  item: ShopifyCartItem,
+  target: URLSearchParams,
+) {
+  const newProperties = item.properties;
+  const newKeys = new Set(Object.keys(newProperties ?? {}));
+
+  // Diff the keys to see if we need to do anything
+  const existingKeys = new Set<string>();
+  target.forEach((_value, key) => {
+    existingKeys.add(key);
+  });
+
+  const keysToRemove = new Set<string>();
+  for (const key of existingKeys) {
+    if (!newKeys.has(key)) {
+      keysToRemove.add(key);
+    }
+  }
+
+  // Add the new properties
+  for (const [key, value] of Object.entries(newProperties ?? {})) {
+    target.set(`properties[${key}]`, value);
+  }
+
+  // Disable the checkout redirect if this is a preorder
+  if (ShopifyCart.hasPreorderAttributes(item)) {
+    target.delete("checkout");
+  }
+}
+
+function extractAddToCartProperties(
+  data: FormData | URLSearchParams | JSONObject,
+) {
+  if (data instanceof FormData || data instanceof URLSearchParams) {
+    const properties: Record<string, string> = {};
+
+    data.forEach((value, key) => {
+      const keyMatch = key.match(/.*\[(.*)\]/);
+
+      if (keyMatch && keyMatch.length > 0) {
+        const propKey = keyMatch[1];
+        properties[propKey] = value as string;
+      }
+    });
+
+    return properties;
+  }
+
+  return (data.properties ?? {}) as Record<string, string>;
+}

--- a/src/shopify-cart.ts
+++ b/src/shopify-cart.ts
@@ -1,0 +1,85 @@
+import { fetchVariantsPreorderState } from "./api";
+import { Cart, CartItem, PreorderAttributes } from "./cart";
+import { JSONObject } from "./interceptors";
+
+export type ShopifyCartItem = CartItem & {
+  id?: string;
+  quantity?: number;
+  properties?: Record<string, string>;
+};
+
+const ShopifyCart: Cart<ShopifyCartItem> = {
+  hasPreorderAttributes(item: ShopifyCartItem): boolean {
+    return !!item.properties?.["__releaseId"];
+  },
+
+  addPreorderAttributes(item: ShopifyCartItem, attrs: PreorderAttributes) {
+    return {
+      id: item.id,
+      variantId: item.variantId,
+      properties: {
+        ...item.properties,
+        __releaseId: attrs.releaseId,
+        "Purple Dot Pre-order": attrs.displayShipDates,
+      },
+    };
+  },
+
+  removePreorderAttributes(item: ShopifyCartItem) {
+    return {
+      id: item.id,
+      variantId: item.variantId,
+      properties: Object.fromEntries(
+        Object.entries(item.properties ?? {}).filter(
+          ([key]) => key !== "__releaseId" && key !== "Purple Dot Pre-order",
+        ),
+      ),
+    };
+  },
+
+  async fetchItems() {
+    // TODO: Add the locale to the URL
+    const response = await fetch("/cart.js");
+    const data = await response.json();
+
+    return data.items.map((item: JSONObject) => {
+      return {
+        id: item.key ?? item.id ?? item.variant_id,
+        variantId: item.variant_id,
+        properties: item.properties,
+      };
+    });
+  },
+
+  async decrementQuantity(id: string) {
+    // TODO: Fetch the cart and decrement one of the matching line items
+  },
+};
+
+export async function updatePreorderAttributes(
+  item: ShopifyCartItem,
+): Promise<ShopifyCartItem | null> {
+  const variantId = parseFloat(item.variantId);
+  const preorderState = await fetchVariantsPreorderState(variantId);
+
+  if (preorderState == null) {
+    return null;
+  }
+
+  if (preorderState.state === "ON_PREORDER" && preorderState.waitlist) {
+    const attributes = {
+      releaseId: preorderState.waitlist.id,
+      displayShipDates: preorderState.waitlist.display_dispatch_date,
+    };
+
+    return ShopifyCart.addPreorderAttributes(item, attributes);
+  }
+
+  if (ShopifyCart.hasPreorderAttributes(item)) {
+    return ShopifyCart.removePreorderAttributes(item);
+  }
+
+  return null;
+}
+
+export default ShopifyCart;

--- a/tests/shopify-cart-interceptor.test.ts
+++ b/tests/shopify-cart-interceptor.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { ShopifyCartAddInterceptor } from "../src/shopify-cart-interceptor";
+
+const jsonHeader = { "Content-Type": "application/json" };
+const formHeader = { "Content-Type": "application/x-www-form-urlencoded" };
+
+describe("ShopifyAddToCartInterceptor", () => {
+  let fetchSpy;
+
+  beforeEach(() => {
+    window.fetch = fetchSpy = vi.fn(() => Promise.resolve(new Response()));
+  });
+
+  describe("AJAX request", () => {
+    test("not on preorder", async () => {
+      new ShopifyCartAddInterceptor();
+
+      await window.fetch("/cart/add.js", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          items: [{ id: 1 }],
+        }),
+      });
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v1/variants/preorder-state?variant_id=1"),
+        undefined,
+      );
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/cart/add.js"),
+        {
+          body: '{"items":[{"id":1}]}',
+          headers: {
+            "Content-Type": "application/json",
+          },
+          method: "POST",
+        },
+      );
+    });
+
+    test("on preorder", async () => {
+      fetchSpy.mockImplementation(async (input: string, init) => {
+        if (input.endsWith("/api/v1/variants/preorder-state?variant_id=1")) {
+          return new Response(
+            JSON.stringify({
+              data: {
+                state: "ON_PREORDER",
+                waitlist: { id: 123, display_dispatch_date: "tomorrow" },
+              },
+            }),
+            {
+              headers: {
+                "Content-Type": "application/json",
+              },
+            },
+          );
+        } else {
+          return new Response();
+        }
+      });
+
+      new ShopifyCartAddInterceptor();
+
+      await window.fetch("/cart/add.js", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          items: [{ id: 1 }],
+        }),
+      });
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v1/variants/preorder-state?variant_id=1"),
+        undefined,
+      );
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/cart/add.js"),
+        {
+          body: '{"items":[{"properties":{"__releaseId":123,"Purple Dot Pre-order":"tomorrow"}}]}',
+          headers: {
+            "Content-Type": "application/json",
+          },
+          method: "POST",
+        },
+      );
+    });
+  });
+
+  describe("Form request", () => {
+    test("not on preorder", async () => {
+      new ShopifyCartAddInterceptor();
+
+      await window.fetch("/cart/add", {
+        method: "POST",
+        headers: formHeader,
+        body: "id=1",
+      });
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v1/variants/preorder-state?variant_id=1"),
+        undefined,
+      );
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/cart/add"),
+        {
+          body: "id=1",
+          headers: formHeader,
+          method: "POST",
+        },
+      );
+    });
+
+    test("on preorder", async () => {
+      fetchSpy.mockImplementation(async (input: string, init) => {
+        if (input.endsWith("/api/v1/variants/preorder-state?variant_id=1")) {
+          return new Response(
+            JSON.stringify({
+              data: {
+                state: "ON_PREORDER",
+                waitlist: { id: 123, display_dispatch_date: "tomorrow" },
+              },
+            }),
+            {
+              headers: jsonHeader,
+            },
+          );
+        } else {
+          return new Response();
+        }
+      });
+
+      new ShopifyCartAddInterceptor();
+
+      await window.fetch("/cart/add.js", {
+        method: "POST",
+        headers: formHeader,
+        body: "id=1",
+      });
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v1/variants/preorder-state?variant_id=1"),
+        undefined,
+      );
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/cart/add.js"),
+        {
+          body: "id=1&quantity=1&properties%5B__releaseId%5D=123&properties%5BPurple+Dot+Pre-order%5D=tomorrow",
+          headers: formHeader,
+          method: "POST",
+        },
+      );
+    });
+  });
+});

--- a/tests/shopify-cart.test.ts
+++ b/tests/shopify-cart.test.ts
@@ -1,0 +1,51 @@
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+
+import ShopifyCart from '../src/shopify-cart'
+
+describe("fetch", () => {
+  describe('hasPreorderAttributes', () => {
+    test('returns true if the item has a __releaseId property', () => {
+      const item = { variantId: '1', properties: { __releaseId: '123' } };
+      expect(ShopifyCart.hasPreorderAttributes(item)).toBe(true);
+    });
+
+    test('returns false if the item does not have a __releaseId property', () => {
+      const item = { variantId: '1', properties: { foo: 'bar' } };
+      expect(ShopifyCart.hasPreorderAttributes(item)).toBe(false);
+    });
+  });
+
+  describe('addPreorderAttributes', () => {
+    test('adds attributes to the item properties', () => {
+      const item = { variantId: '1', properties: { foo: 'bar' } };
+      const attributes = { releaseId: '123', displayShipDates: 'tomorrow' };
+
+      const newItem = ShopifyCart.addPreorderAttributes(item, attributes);
+
+      expect(newItem.properties).toEqual({
+        foo: 'bar',
+        __releaseId: '123',
+        'Purple Dot Pre-order': 'tomorrow',
+      });
+    });
+  });
+
+  describe('removePreorderAttributes', () => {
+    test('adds attributes to the item properties', () => {
+      const item = {
+        variantId: '1', properties: {
+          foo: 'bar', __releaseId: '123',
+          'Purple Dot Pre-order': 'tomorrow',
+        }
+      };
+
+      const newItem = ShopifyCart.removePreorderAttributes(item);
+
+      expect(newItem.properties).toEqual({
+        foo: 'bar'
+      });
+    });
+  });
+});


### PR DESCRIPTION
This adds the generic Cart interface and an implementation of ShopifyCart and uses it to power an AddToCartInterceptor capable of fixing up combined checkout style add to cart calls that use the Shopify AJAX or `<form>` style.

Also TypeScript wasn't working properly in my IDE so I fixed it based on https://yarnpkg.com/getting-started/editor-sdks 