### PR TITLE
feat: track added_to_cart events

### DIFF
--- a/src/shopify-cart-interceptors.ts
+++ b/src/shopify-cart-interceptors.ts
@@ -9,6 +9,7 @@ import ShopifyCart, {
   ShopifyCartItem,
   updatePreorderAttributes,
 } from "./shopify-cart";
+import { trackEvent } from "./tracking";
 
 function shouldIntercept(input: string | URL) {
   return shopifyUrlStartsWith(input, "cart/add");
@@ -42,6 +43,13 @@ async function onAddToCart([input, init]: [
 
     // Convert the Shopify add to cart request to our Cart API format.
     const newItems = getItemsFromRequest(requestBody);
+
+    for (const item of newItems) {
+      trackEvent("integration.added_to_cart", {
+        variant_id: item.variantId,
+        release_id: item.properties?.["__releaseId"] ?? null,
+      }).catch(() => {});
+    }
 
     // Keep track of if we find anything that needs changing so we can avoid changing things that don't need it.
     let changed = false;

--- a/src/tracking/track-event.ts
+++ b/src/tracking/track-event.ts
@@ -5,7 +5,7 @@ import getDeviceId from "./device-id";
 
 export async function trackEvent(
   name: string,
-  attrs: Record<string, string> = {},
+  attrs: Record<string, string | null> = {},
 ) {
   const { deviceId, storage } = getDeviceId();
   const cartToken = cookies.get("cart") ?? null;


### PR DESCRIPTION
This event is the same as what `shopify-script.js` tracks.