### PR TITLE
feat: track client-side url changes as page views

### DIFF
--- a/src/custom-events.ts
+++ b/src/custom-events.ts
@@ -1,0 +1,20 @@
+export function onDOMContentLoaded(cb: () => {}) {
+  if (document.readyState === "loading") {
+    // Loading hasn't finished yet
+    document.addEventListener("DOMContentLoaded", cb);
+  } else {
+    // `DOMContentLoaded` has already fired
+    cb();
+  }
+}
+
+export function onLocationChange(cb: () => {}) {
+  let oldUrl = window.location.href;
+  new MutationObserver(() => {
+    const newUrl = window.location.href;
+    if (oldUrl !== newUrl) {
+      cb();
+      oldUrl = newUrl;
+    }
+  }).observe(document.body);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { injectComponentScripts } from "./web-components";
 import { trackPageView } from "./tracking";
+import { onDOMContentLoaded, onLocationChange } from "./custom-events";
 
 export interface PurpleDotConfig {
   apiKey: string;
@@ -13,14 +14,5 @@ export function init(config: PurpleDotConfig) {
   injectComponentScripts();
 }
 
-function onDOMContentLoaded(cb: () => {}) {
-  if (document.readyState === "loading") {
-    // Loading hasn't finished yet
-    document.addEventListener("DOMContentLoaded", cb);
-  } else {
-    // `DOMContentLoaded` has already fired
-    cb();
-  }
-}
-
 onDOMContentLoaded(() => trackPageView().catch(() => {}));
+onLocationChange(() => trackPageView().catch(() => {}));


### PR DESCRIPTION
This adds tracking for client-side navigation, because SPAs are likely to do that.