### PR TITLE
refactor: export all modules from index.ts

### DIFF
--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -1,28 +1,31 @@
-describe('opening a checkout', () => {
-  it('can open a checkout for the Demo store', () => {
-    cy.visit('http://127.0.0.1:8080/dist/index')
-    cy.window().should('have.attr', 'PurpleDot');
-
+describe("opening a checkout", () => {
+  it("can open a checkout for the Demo store", () => {
+    cy.visit("http://127.0.0.1:8080/dist/index");
+    cy.window().should("have.attr", "PurpleDot");
 
     cy.window().then((win) => {
-      win.PurpleDot.init({ apiKey: 'b351faa2-8693-4c09-b814-759beed90d0b' });
+      win.PurpleDot.init({ apiKey: "b351faa2-8693-4c09-b814-759beed90d0b" });
     });
 
     // Wait for the components to be registered
     cy.wait(1000);
 
-    cy.setCookie('cart', 'bcc9daa54d4eb89b36df5321dd087ab2')
+    cy.setCookie("cart", "bcc9daa54d4eb89b36df5321dd087ab2");
 
-    cy.window().then((win) => {
+    cy.window().then(async (win) => {
       win.PurpleDot.checkout.open({
-        cartId: win.PurpleDot.ShopifyAJAXCart.getCartID(),
+        cartId: await win.PurpleDot.ShopifyAJAXCart.getCartId(),
       });
     });
 
-    cy.get('#checkout-iframe').should('exist');
-    cy.get('#checkout-iframe').should('have.attr', 'src').should('include', 'https://www.purpledotprice.com/embedded-checkout/combined-checkout?apiKey=b351faa2-8693-4c09-b814-759beed90d0b')
+    cy.get("#checkout-iframe").should("exist");
+    cy.get("#checkout-iframe")
+      .should("have.attr", "src")
+      .should(
+        "include",
+        "https://www.purpledotprice.com/embedded-checkout/combined-checkout?apiKey=b351faa2-8693-4c09-b814-759beed90d0b",
+      );
 
-    cy.getIframeBody('#checkout-iframe')
-      .should('contain', 'Your cart');
-  })
-})
+    cy.getIframeBody("#checkout-iframe").should("contain", "Your cart");
+  });
+});

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -8,14 +8,14 @@ describe('opening a checkout', () => {
       win.PurpleDot.init({ apiKey: 'b351faa2-8693-4c09-b814-759beed90d0b' });
     });
 
-    // Wait for the components to be registered 
+    // Wait for the components to be registered
     cy.wait(1000);
 
     cy.setCookie('cart', 'bcc9daa54d4eb89b36df5321dd087ab2')
 
     cy.window().then((win) => {
       win.PurpleDot.checkout.open({
-        cartId: win.PurpleDot.cart.getShopifyAJAXCartID(),
+        cartId: win.PurpleDot.ShopifyAJAXCart.getCartID(),
       });
     });
 

--- a/cypress/support/built-script.ts
+++ b/cypress/support/built-script.ts
@@ -1,4 +1,4 @@
-import * as PurpleDot from '../../src/index';
+import * as PurpleDot from "../../src/index";
 
 declare global {
   interface Window {

--- a/cypress/support/built-script.ts
+++ b/cypress/support/built-script.ts
@@ -1,4 +1,12 @@
-import * as PurpleDot from "../../src/index";
+import * as PurpleDotMain from "../../src/index";
+import * as checkout from "../../src/checkout";
+import { ShopifyAJAXCart } from "../../src/shopify-cart";
+
+const PurpleDot = {
+  ...PurpleDotMain,
+  checkout,
+  ShopifyAJAXCart,
+};
 
 declare global {
   interface Window {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,10 +24,10 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
-Cypress.Commands.add('getIframeBody', (selector, options) => {
-  Cypress.log({ name: 'get', message: 'getIframeBody' });
+Cypress.Commands.add("getIframeBody", (selector, options) => {
+  Cypress.log({ name: "get", message: "getIframeBody" });
   cy.get(selector, options)
-    .its('0.contentDocument.body')
-    .should('not.be.empty')
+    .its("0.contentDocument.body")
+    .should("not.be.empty")
     .then(cy.wrap);
 });

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import "./commands";
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/cypress/support/webpack.config.js
+++ b/cypress/support/webpack.config.js
@@ -1,5 +1,5 @@
 const webpack = require("webpack");
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 const path = require("path");
 
 module.exports = {
@@ -13,13 +13,13 @@ module.exports = {
     rules: [
       {
         test: /\.ts$/, // Match TypeScript files
-        use: 'ts-loader', // Use ts-loader for TypeScript files
+        use: "ts-loader", // Use ts-loader for TypeScript files
         exclude: /node_modules/, // Exclude node_modules from being processed by the loader
       },
     ],
   },
   resolve: {
-    extensions: ['.ts', '.js'], // Add '.ts' and '.js' to the list of extensions Webpack should resolve
+    extensions: [".ts", ".js"], // Add '.ts' and '.js' to the list of extensions Webpack should resolve
   },
   plugins: [new HtmlWebpackPlugin()],
-}
+};

--- a/package.json
+++ b/package.json
@@ -23,8 +23,17 @@
     "url": "https://github.com/purple-dot/browser/issues"
   },
   "homepage": "https://github.com/purple-dot/browser#readme",
-  "files": ["dist/*"],
-  "main": "dist/index.js",
+  "files": [
+    "dist/*"
+  ],
+  "exports": {
+    ".": "dist/index.js",
+    "./api": "dist/api.js",
+    "./checkout": "dist/checkout.js",
+    "./cart": "dist/cart.js",
+    "./shopify-ajax-cart": "dist/shopify-cart",
+    "./shopify-ajax-interceptors": "dist/shopify-cart-interceptors"
+  },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.2",
     "@types/js-cookie": "^3.0.3",
@@ -45,5 +54,8 @@
   "dependencies": {
     "js-cookie": "^3.0.5",
     "uuid": "^9.0.0"
+  },
+  "engines": {
+    "node": ">=10.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "version": "0.0.7",
   "scripts": {
     "build": "tsc",
-    "lint": "rome ci src/",
-    "format": "rome check --apply-unsafe src/ && rome format --write src/",
+    "lint": "rome ci src/ tests/ cypress/",
+    "format": "rome check --apply-unsafe src/ tests/ cypress/ && rome format --write src/ tests/ cypress/",
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "start:test-http-server": "cd cypress/support && yarn dlx http-server . -p 8080",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@purple-dot/browser",
   "description": "Purple Dot Browser SDK",
   "license": "Apache-2.0",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "scripts": {
     "build": "tsc",
     "lint": "rome ci src/",

--- a/src/cart.ts
+++ b/src/cart.ts
@@ -17,6 +17,7 @@ export interface Cart<T extends CartItem> {
 
   // Queries
   fetchItems: () => Promise<Required<T>[]>;
+  getCartId: () => Promise<string | null>;
 
   // Mutations
   decrementQuantity: (id: string) => Promise<void>;

--- a/src/checkout.ts
+++ b/src/checkout.ts
@@ -1,0 +1,7 @@
+export function open({ cartId }: { cartId: string; currency: string }) {
+  const element = document.createElement("purple-dot-checkout");
+  document.body.appendChild(element);
+
+  // @ts-ignore
+  element.open({ cartId });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
-import cookies from "js-cookie";
 import { injectComponentScripts } from "./web-components";
 import { trackPageView } from "./tracking";
 import { onDOMContentLoaded, onLocationChange } from "./custom-events";
-
-const HOST_URL = "https://www.purpledotprice.com";
+import * as checkout from "./checkout";
+import * as cart from "./cart";
+import * as api from "./api";
+import { ShopifyAJAXCart } from "./shopify-cart";
+import * as ShopifyAJAXCartInterceptors from "./interceptors";
 
 export interface PurpleDotConfig {
   apiKey: string;
@@ -17,22 +19,7 @@ export function init(config: PurpleDotConfig) {
   injectComponentScripts();
 }
 
-export const cart = {
-  getShopifyAJAXCartID() {
-    const shopifyCartId = cookies.get("cart");
-    return shopifyCartId;
-  },
-};
-
-export const checkout = {
-  open({ cartId }: { cartId: string; currency: string }) {
-    const element = document.createElement("purple-dot-checkout");
-    document.body.appendChild(element);
-
-    // @ts-ignore
-    element.open({ cartId });
-  },
-};
-
 onDOMContentLoaded(() => trackPageView().catch(() => {}));
 onLocationChange(() => trackPageView().catch(() => {}));
+
+export { cart, checkout, api, ShopifyAJAXCart, ShopifyAJAXCartInterceptors };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,6 @@
 import { injectComponentScripts } from "./web-components";
 import { trackPageView } from "./tracking";
 import { onDOMContentLoaded, onLocationChange } from "./custom-events";
-import * as checkout from "./checkout";
-import * as cart from "./cart";
-import * as api from "./api";
-import { ShopifyAJAXCart } from "./shopify-cart";
-import * as ShopifyAJAXCartInterceptors from "./interceptors";
 
 export interface PurpleDotConfig {
   apiKey: string;
@@ -21,5 +16,3 @@ export function init(config: PurpleDotConfig) {
 
 onDOMContentLoaded(() => trackPageView().catch(() => {}));
 onLocationChange(() => trackPageView().catch(() => {}));
-
-export { cart, checkout, api, ShopifyAJAXCart, ShopifyAJAXCartInterceptors };

--- a/src/shopify-cart.ts
+++ b/src/shopify-cart.ts
@@ -1,19 +1,20 @@
+import cookies from "js-cookie";
 import { fetchVariantsPreorderState } from "./api";
 import { Cart, CartItem, PreorderAttributes } from "./cart";
 import { JSONObject } from "./interceptors";
 
-export type ShopifyCartItem = CartItem & {
+export type ShopifyAJAXCartItem = CartItem & {
   id?: string;
   quantity?: number;
   properties?: Record<string, string>;
 };
 
-export const ShopifyCart: Cart<ShopifyCartItem> = {
-  hasPreorderAttributes(item: ShopifyCartItem): boolean {
+export const ShopifyAJAXCart: Cart<ShopifyAJAXCartItem> = {
+  hasPreorderAttributes(item: ShopifyAJAXCartItem): boolean {
     return !!item.properties?.["__releaseId"];
   },
 
-  addPreorderAttributes(item: ShopifyCartItem, attrs: PreorderAttributes) {
+  addPreorderAttributes(item: ShopifyAJAXCartItem, attrs: PreorderAttributes) {
     return {
       id: item.id,
       variantId: item.variantId,
@@ -25,7 +26,7 @@ export const ShopifyCart: Cart<ShopifyCartItem> = {
     };
   },
 
-  removePreorderAttributes(item: ShopifyCartItem) {
+  removePreorderAttributes(item: ShopifyAJAXCartItem) {
     return {
       id: item.id,
       variantId: item.variantId,
@@ -83,11 +84,16 @@ export const ShopifyCart: Cart<ShopifyCartItem> = {
   async navigateToCheckout() {
     window.location.href = "/checkout";
   },
+
+  async getCartId() {
+    const shopifyCartId = cookies.get("cart");
+    return shopifyCartId ?? null;
+  },
 };
 
 export async function updatePreorderAttributes(
-  item: ShopifyCartItem,
-): Promise<ShopifyCartItem | null> {
+  item: ShopifyAJAXCartItem,
+): Promise<ShopifyAJAXCartItem | null> {
   const variantId = parseFloat(item.variantId);
   const preorderState = await fetchVariantsPreorderState(variantId);
 
@@ -101,11 +107,11 @@ export async function updatePreorderAttributes(
       displayShipDates: preorderState.waitlist.display_dispatch_date,
     };
 
-    return ShopifyCart.addPreorderAttributes(item, attributes);
+    return ShopifyAJAXCart.addPreorderAttributes(item, attributes);
   }
 
-  if (ShopifyCart.hasPreorderAttributes(item)) {
-    return ShopifyCart.removePreorderAttributes(item);
+  if (ShopifyAJAXCart.hasPreorderAttributes(item)) {
+    return ShopifyAJAXCart.removePreorderAttributes(item);
   }
 
   return null;

--- a/tests/shopify-cart-interceptors.test.ts
+++ b/tests/shopify-cart-interceptors.test.ts
@@ -2,7 +2,7 @@
 
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { ShopifyCartAddInterceptor } from "../src/shopify-cart-interceptors";
+import { ShopifyAJAXCartAddInterceptor } from "../src/shopify-cart-interceptors";
 
 const jsonHeader = { "Content-Type": "application/json" };
 const formHeader = { "Content-Type": "application/x-www-form-urlencoded" };
@@ -16,7 +16,7 @@ describe("ShopifyAddToCartInterceptor", () => {
 
   describe("AJAX request", () => {
     test("not on preorder", async () => {
-      new ShopifyCartAddInterceptor();
+      new ShopifyAJAXCartAddInterceptor();
 
       await window.fetch("/cart/add.js", {
         method: "POST",
@@ -64,7 +64,7 @@ describe("ShopifyAddToCartInterceptor", () => {
         }
       });
 
-      new ShopifyCartAddInterceptor();
+      new ShopifyAJAXCartAddInterceptor();
 
       await window.fetch("/cart/add.js", {
         method: "POST",
@@ -94,7 +94,7 @@ describe("ShopifyAddToCartInterceptor", () => {
 
   describe("Form request", () => {
     test("not on preorder", async () => {
-      new ShopifyCartAddInterceptor();
+      new ShopifyAJAXCartAddInterceptor();
 
       await window.fetch("/cart/add", {
         method: "POST",
@@ -136,7 +136,7 @@ describe("ShopifyAddToCartInterceptor", () => {
         }
       });
 
-      new ShopifyCartAddInterceptor();
+      new ShopifyAJAXCartAddInterceptor();
 
       await window.fetch("/cart/add.js", {
         method: "POST",

--- a/tests/shopify-cart.test.ts
+++ b/tests/shopify-cart.test.ts
@@ -1,50 +1,50 @@
-
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-
-import ShopifyCart from '../src/shopify-cart'
+import { ShopifyAJAXCart } from "../src/shopify-cart";
 
 describe("fetch", () => {
-  describe('hasPreorderAttributes', () => {
-    test('returns true if the item has a __releaseId property', () => {
-      const item = { variantId: '1', properties: { __releaseId: '123' } };
-      expect(ShopifyCart.hasPreorderAttributes(item)).toBe(true);
+  describe("hasPreorderAttributes", () => {
+    test("returns true if the item has a __releaseId property", () => {
+      const item = { variantId: "1", properties: { __releaseId: "123" } };
+      expect(ShopifyAJAXCart.hasPreorderAttributes(item)).toBe(true);
     });
 
-    test('returns false if the item does not have a __releaseId property', () => {
-      const item = { variantId: '1', properties: { foo: 'bar' } };
-      expect(ShopifyCart.hasPreorderAttributes(item)).toBe(false);
+    test("returns false if the item does not have a __releaseId property", () => {
+      const item = { variantId: "1", properties: { foo: "bar" } };
+      expect(ShopifyAJAXCart.hasPreorderAttributes(item)).toBe(false);
     });
   });
 
-  describe('addPreorderAttributes', () => {
-    test('adds attributes to the item properties', () => {
-      const item = { variantId: '1', properties: { foo: 'bar' } };
-      const attributes = { releaseId: '123', displayShipDates: 'tomorrow' };
+  describe("addPreorderAttributes", () => {
+    test("adds attributes to the item properties", () => {
+      const item = { variantId: "1", properties: { foo: "bar" } };
+      const attributes = { releaseId: "123", displayShipDates: "tomorrow" };
 
-      const newItem = ShopifyCart.addPreorderAttributes(item, attributes);
+      const newItem = ShopifyAJAXCart.addPreorderAttributes(item, attributes);
 
       expect(newItem.properties).toEqual({
-        foo: 'bar',
-        __releaseId: '123',
-        'Purple Dot Pre-order': 'tomorrow',
+        foo: "bar",
+        __releaseId: "123",
+        "Purple Dot Pre-order": "tomorrow",
       });
     });
   });
 
-  describe('removePreorderAttributes', () => {
-    test('adds attributes to the item properties', () => {
+  describe("removePreorderAttributes", () => {
+    test("adds attributes to the item properties", () => {
       const item = {
-        variantId: '1', properties: {
-          foo: 'bar', __releaseId: '123',
-          'Purple Dot Pre-order': 'tomorrow',
-        }
+        variantId: "1",
+        properties: {
+          foo: "bar",
+          __releaseId: "123",
+          "Purple Dot Pre-order": "tomorrow",
+        },
       };
 
-      const newItem = ShopifyCart.removePreorderAttributes(item);
+      const newItem = ShopifyAJAXCart.removePreorderAttributes(item);
 
       expect(newItem.properties).toEqual({
-        foo: 'bar'
+        foo: "bar",
       });
     });
   });


### PR DESCRIPTION
When I tried installing and using the package, I realised our import paths where wonky. Previously, we thought we could use it like `import { open } from '@purple-dot/browser/checkout'`, but because we use a `./dist` folder, it actually ended up being `import { open } from '@purple-dot/browser/dist/checkout'`. I looked and couldn't find a good way to get rid of the dist folder on publish. Therefore I suggest we export everything from `index.ts` so it can be imported as `import { checkout, api } from '@purple-dot/browser'; checkout.open();`.