### PR TITLE
fix: enforce always returning data in the same format

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "rome ci src/ tests/ cypress/",
+    "lint:fix": "rome check --apply-unsafe src/ tests/ cypress/ && rome format --write src/ tests/ cypress/",
     "format": "rome check --apply-unsafe src/ tests/ cypress/ && rome format --write src/ tests/ cypress/",
     "test": "vitest",
     "coverage": "vitest run --coverage",

--- a/src/shopify-cart-interceptors.ts
+++ b/src/shopify-cart-interceptors.ts
@@ -1,7 +1,10 @@
 import {
+  BodyData,
   JSONObject,
   RequestInterceptor,
+  
   makeFetchRequestBody,
+  
   parseFetchRequestBody,
   shopifyUrlStartsWith,
 } from "./interceptors";
@@ -33,8 +36,8 @@ async function onAddToCart([input, init]: [
   }
 
   if (init.method?.toUpperCase() === "POST" || init.body) {
-    let requestBody: ReturnType<typeof parseFetchRequestBody>;
-
+   
+    let requestBody: BodyData;
     try {
       requestBody = parseFetchRequestBody(init);
     } catch (err) {
@@ -72,7 +75,7 @@ async function onAddToCart([input, init]: [
     }
 
     // Try to convert it back to the same kind of request we started with.
-    let newBody: FormData | URLSearchParams | JSONObject = requestBody;
+    let newBody = requestBody;
 
     if ("items" in requestBody) {
       newBody = shopifyAJAXAddToCart(updatedItems);

--- a/src/shopify-cart-interceptors.ts
+++ b/src/shopify-cart-interceptors.ts
@@ -2,9 +2,7 @@ import {
   BodyData,
   JSONObject,
   RequestInterceptor,
-  
   makeFetchRequestBody,
-  
   parseFetchRequestBody,
   shopifyUrlStartsWith,
 } from "./interceptors";
@@ -36,7 +34,6 @@ async function onAddToCart([input, init]: [
   }
 
   if (init.method?.toUpperCase() === "POST" || init.body) {
-   
     let requestBody: BodyData;
     try {
       requestBody = parseFetchRequestBody(init);

--- a/tests/shopify-cart-interceptors.test.ts
+++ b/tests/shopify-cart-interceptors.test.ts
@@ -14,7 +14,7 @@ describe("ShopifyAddToCartInterceptor", () => {
     window.fetch = fetchSpy = vi.fn(() => Promise.resolve(new Response()));
   });
 
-  describe("AJAX request", () => {
+  describe("json request", () => {
     test("not on preorder", async () => {
       new ShopifyAJAXCartAddInterceptor();
 
@@ -86,74 +86,6 @@ describe("ShopifyAddToCartInterceptor", () => {
           headers: {
             "Content-Type": "application/json",
           },
-          method: "POST",
-        },
-      );
-    });
-  });
-
-  describe("Form request", () => {
-    test("not on preorder", async () => {
-      new ShopifyAJAXCartAddInterceptor();
-
-      await window.fetch("/cart/add", {
-        method: "POST",
-        headers: formHeader,
-        body: "id=1",
-      });
-
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.stringContaining("/api/v1/variants/preorder-state?variant_id=1"),
-        undefined,
-      );
-
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.stringContaining("/cart/add"),
-        {
-          body: "id=1",
-          headers: formHeader,
-          method: "POST",
-        },
-      );
-    });
-
-    test("on preorder", async () => {
-      fetchSpy.mockImplementation(async (input: string, init) => {
-        if (input.endsWith("/api/v1/variants/preorder-state?variant_id=1")) {
-          return new Response(
-            JSON.stringify({
-              data: {
-                state: "ON_PREORDER",
-                waitlist: { id: 123, display_dispatch_date: "tomorrow" },
-              },
-            }),
-            {
-              headers: jsonHeader,
-            },
-          );
-        } else {
-          return new Response();
-        }
-      });
-
-      new ShopifyAJAXCartAddInterceptor();
-
-      await window.fetch("/cart/add.js", {
-        method: "POST",
-        headers: formHeader,
-        body: "id=1",
-      });
-
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.stringContaining("/api/v1/variants/preorder-state?variant_id=1"),
-        undefined,
-      );
-
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.stringContaining("/cart/add.js"),
-        {
-          body: "id=1&quantity=1&properties%5B__releaseId%5D=123&properties%5BPurple+Dot+Pre-order%5D=tomorrow",
-          headers: formHeader,
           method: "POST",
         },
       );


### PR DESCRIPTION
Attempt to fix the interceptor encoding issue. Maybe we can huddle to test this out?