### PR TITLE
refactor: configure cartAdapter in init()

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 ```javascript
 import { init } from '@purple-dot/browser';
+import { ShopifyAJAXCart } from '@purple-dot/browser/shopify-ajax-cart';
 
 init({
   apiKey: 'xxx',
+  cartAdapter: ShopifyAJAXCart,
 });
 ```
 
@@ -18,24 +20,20 @@ await api.fetchProductsPreorderState('test-product');
 await api.fetchVariantsPreorderState(12345);
 ```
 
-### Shopify AJAX Cart
+### Cart
 
 ```javascript
-import { ShopifyAJAXCart } from '@purple-dot/browser/shopify-ajax-cart';
 import { cartHasPreorderItem } from '@purple-dot/browser/cart';
 
-await cartHasPreorderItem(ShopifyAJAXCart);
+await cartHasPreorderItem();
 ```
 
 ### Purple Dot Checkout
 
 ```javascript
 import * as checkout from '@purple-dot/browser/checkout';
-import { ShopifyAJAXCart } from '@purple-dot/browser/shopify-ajax-cart';
 
-await checkout.open({
-  cartId: await ShopifyAJAXCart.getCartId(),
-});
+await checkout.open();
 ```
 
 ### Shopify AJAX Cart Interceptors

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -4,7 +4,10 @@ describe("opening a checkout", () => {
     cy.window().should("have.attr", "PurpleDot");
 
     cy.window().then((win) => {
-      win.PurpleDot.init({ apiKey: "b351faa2-8693-4c09-b814-759beed90d0b" });
+      win.PurpleDot.init({
+        apiKey: "b351faa2-8693-4c09-b814-759beed90d0b",
+        cartAdapter: win.PurpleDot.ShopifyAJAXCart,
+      });
     });
 
     // Wait for the components to be registered
@@ -13,9 +16,7 @@ describe("opening a checkout", () => {
     cy.setCookie("cart", "bcc9daa54d4eb89b36df5321dd087ab2");
 
     cy.window().then(async (win) => {
-      win.PurpleDot.checkout.open({
-        cartId: await win.PurpleDot.ShopifyAJAXCart.getCartId(),
-      });
+      await win.PurpleDot.checkout.open();
     });
 
     cy.get("#checkout-iframe").should("exist");

--- a/src/cart.ts
+++ b/src/cart.ts
@@ -25,7 +25,16 @@ export interface Cart<T extends CartItem> {
   navigateToCheckout: () => Promise<void>;
 }
 
-export async function cartHasPreorderItem(cart: Cart<CartItem>) {
+export async function cartHasPreorderItem() {
+  const cart = getCartAdapter();
   const items = await cart.fetchItems();
   return items.some((i) => cart.hasPreorderAttributes(i));
+}
+
+export function getCartAdapter(): Cart<CartItem> {
+  const cart = window.PurpleDotConfig?.cartAdapter;
+  if (!cart) {
+    throw new Error("@purple-dot/browser not initialised");
+  }
+  return cart;
 }

--- a/src/checkout.ts
+++ b/src/checkout.ts
@@ -1,11 +1,17 @@
 import { onceCheckoutScriptLoaded } from "./web-components";
+import { getCartAdapter } from "./cart";
 
-export function open({ cartId }: { cartId: string; currency: string }) {
+export async function open(args?: { cartId?: string }) {
   const element = document.createElement("purple-dot-checkout");
   document.body.appendChild(element);
 
-  onceCheckoutScriptLoaded(() => {
-    // @ts-ignore
-    element.open({ cartId });
+  return new Promise<void>((resolve) => {
+    onceCheckoutScriptLoaded(async () => {
+      const cartId = args?.cartId ?? (await getCartAdapter().getCartId());
+      // @ts-ignore
+      element.open({ cartId });
+
+      resolve();
+    });
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,14 +5,18 @@ import {
   onLocationChange,
   onPurpleDotEvent,
 } from "./custom-events";
+import { Cart, CartItem } from "./cart";
+import { ShopifyAJAXCart } from "./shopify-cart";
 
 export interface PurpleDotConfig {
   apiKey: string;
+  cartAdapter?: Cart<CartItem>;
 }
 
 export function init(config: PurpleDotConfig) {
   window.PurpleDotConfig = {
     apiKey: config.apiKey,
+    cartAdapter: config.cartAdapter ?? ShopifyAJAXCart,
   };
 
   injectComponentScripts();

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,7 +1,10 @@
+import type { Cart, CartItem } from "./cart";
+
 export declare global {
   interface Window {
     PurpleDotConfig?: {
       apiKey: string;
+      cartAdapter: Cart<CartItem>;
     };
 
     Shopify?: {


### PR DESCRIPTION
API improvement: instead of having to pass the right cart adapter to different functions provided by the library, configure the cart adapter in `init()` and make all functions use the configured one.