### PR TITLE
refactor: export ShopifyAJAXCart as class and make types work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,23 +25,24 @@ jobs:
           root: ~/repo
           paths: .
 
-  lint: 
+  lint:
     executor: node
     resource_class: medium
     steps:
       - attach_workspace:
-          at: ~/repo 
+          at: ~/repo
       - run: yarn lint
-    
-  test: 
+      - run: yarn typecheck
+
+  test:
     executor: node
     resource_class: medium
     steps:
       - attach_workspace:
-          at: ~/repo 
+          at: ~/repo
       - run: yarn test
-      - run: 
-          command: yarn start:test-http-server 
+      - run:
+          command: yarn start:test-http-server
           background: true
       - run: yarn run build:test
       - run: yarn cypress run
@@ -52,7 +53,7 @@ jobs:
           destination: cypress-videos
       - store_artifacts:
           path: /root/repo/cypress/screenshots
-          destination: cypress-screenshots 
+          destination: cypress-screenshots
 
   publish:
     executor: node
@@ -75,7 +76,7 @@ workflows:
       - lint:
           requires:
             - build
-      - test: 
+      - test:
           requires:
             - build
       - publish:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ import { ShopifyAJAXCart } from '@purple-dot/browser/shopify-ajax-cart';
 
 init({
   apiKey: 'xxx',
-  cartAdapter: ShopifyAJAXCart,
+  cartAdapter: new ShopifyAJAXCart(),
 });
 ```
 

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -6,7 +6,7 @@ describe("opening a checkout", () => {
     cy.window().then((win) => {
       win.PurpleDot.init({
         apiKey: "b351faa2-8693-4c09-b814-759beed90d0b",
-        cartAdapter: win.PurpleDot.ShopifyAJAXCart,
+        cartAdapter: new win.PurpleDot.ShopifyAJAXCart(),
       });
     });
 

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "name": "@purple-dot/browser",
   "description": "Purple Dot Browser SDK",
   "license": "Apache-2.0",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "scripts": {
     "build": "tsc",
     "lint": "rome ci src/ tests/ cypress/",
+    "typecheck": "tsc --noEmit && tsc --noEmit --project tsconfig.tests.json",
     "lint:fix": "rome check --apply-unsafe src/ tests/ cypress/ && rome format --write src/ tests/ cypress/",
     "format": "rome check --apply-unsafe src/ tests/ cypress/ && rome format --write src/ tests/ cypress/",
     "test": "vitest",

--- a/src/cart.ts
+++ b/src/cart.ts
@@ -10,7 +10,9 @@ export type PreorderAttributes = {
   displayShipDates: string;
 };
 
-export type CartItem = { id?: string };
+export interface CartItem {
+  id: string;
+}
 
 export interface Cart<T extends CartItem> {
   hasPreorderAttributes: (item: T) => boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import type { Cart, CartItem } from "./cart";
 export function init(config: { apiKey: string; cartAdapter?: Cart<CartItem> }) {
   setConfig({
     apiKey: config.apiKey,
-    cartAdapter: config.cartAdapter ?? ShopifyAJAXCart,
+    cartAdapter: config.cartAdapter ?? new ShopifyAJAXCart(),
   });
 
   if (globalThis.window) {

--- a/src/shopify-ajax-cart-interceptors.ts
+++ b/src/shopify-ajax-cart-interceptors.ts
@@ -2,7 +2,6 @@ import {
   BodyData,
   JSONObject,
   RequestInterceptor,
-  makeFetchRequestBody,
   parseFetchRequestBody,
   shopifyUrlStartsWith,
 } from "./interceptors";
@@ -136,6 +135,7 @@ function getItemsFromRequest(
     if (Array.isArray(items)) {
       for (const item of items) {
         const newItem: ShopifyAJAXCartItem = {
+          id: item.id,
           variantId: `${item.id}`,
           properties: item.properties,
         };
@@ -164,6 +164,7 @@ function getItemsFromRequest(
 
   const pdRequests: ShopifyAJAXCartItem[] = [
     {
+      id: variantId,
       variantId,
       quantity,
       properties,
@@ -247,7 +248,7 @@ function applyURLEncodedAddToCart(
   }
 
   // Disable the checkout redirect if this is a preorder
-  if (ShopifyAJAXCart.hasPreorderAttributes(item)) {
+  if (new ShopifyAJAXCart().hasPreorderAttributes(item)) {
     target.delete("checkout");
   }
 }

--- a/src/shopify-ajax-cart.ts
+++ b/src/shopify-ajax-cart.ts
@@ -3,13 +3,13 @@ import { fetchVariantsPreorderState } from "./api";
 import { Cart, CartItem, PreorderAttributes } from "./cart";
 import { JSONObject } from "./interceptors";
 
-export type ShopifyAJAXCartItem = CartItem & {
+export interface ShopifyAJAXCartItem extends CartItem {
   variantId?: string;
   quantity?: number;
   properties?: Record<string, string>;
-};
+}
 
-class ShopifyAJAXCartClass implements Cart<ShopifyAJAXCartItem> {
+export class ShopifyAJAXCart implements Cart<ShopifyAJAXCartItem> {
   hasPreorderAttributes(item: ShopifyAJAXCartItem): boolean {
     return !!item.properties?.["__releaseId"];
   }
@@ -97,8 +97,6 @@ class ShopifyAJAXCartClass implements Cart<ShopifyAJAXCartItem> {
   }
 }
 
-export const ShopifyAJAXCart = new ShopifyAJAXCartClass();
-
 export async function updatePreorderAttributes(
   item: ShopifyAJAXCartItem,
 ): Promise<ShopifyAJAXCartItem | null> {
@@ -110,17 +108,19 @@ export async function updatePreorderAttributes(
       return null;
     }
 
+    const shopifyAJAXCart = new ShopifyAJAXCart();
+
     if (preorderState.state === "ON_PREORDER" && preorderState.waitlist) {
       const attributes = {
         releaseId: preorderState.waitlist.id,
         displayShipDates: preorderState.waitlist.display_dispatch_date,
       };
 
-      return ShopifyAJAXCart.addPreorderAttributes(item, attributes);
+      return shopifyAJAXCart.addPreorderAttributes(item, attributes);
     }
 
-    if (ShopifyAJAXCart.hasPreorderAttributes(item)) {
-      return ShopifyAJAXCart.removePreorderAttributes(item);
+    if (shopifyAJAXCart.hasPreorderAttributes(item)) {
+      return shopifyAJAXCart.removePreorderAttributes(item);
     }
   }
 

--- a/src/shopify-storefront-cart.ts
+++ b/src/shopify-storefront-cart.ts
@@ -1,19 +1,18 @@
 import { Cart, CartItem, PreorderAttributes } from "./cart";
 
-export type ShopifyStorefrontCartItem = CartItem & {
-  id: string;
-  quantity: number;
-  attributes: { key: string; value: string }[];
-  merchandise: {
+export interface ShopifyStorefrontCartItem extends CartItem {
+  quantity?: number;
+  attributes?: { key: string; value: string }[];
+  merchandise?: {
     id: string;
   };
-};
+}
 
 export class ShopifyStorefrontCart implements Cart<ShopifyStorefrontCartItem> {
   constructor(private origin: string, private accessToken: string) {}
 
   hasPreorderAttributes(item: ShopifyStorefrontCartItem): boolean {
-    return item.attributes.some(({ key }) => key === "__releaseId");
+    return item.attributes?.some(({ key }) => key === "__releaseId") ?? false;
   }
 
   addPreorderAttributes(
@@ -23,7 +22,7 @@ export class ShopifyStorefrontCart implements Cart<ShopifyStorefrontCartItem> {
     return {
       ...item,
       attributes: [
-        ...item.attributes,
+        ...(item.attributes ?? []),
         { key: "__releaseId", value: attrs.releaseId },
         { key: "Purple Dot Pre-order", value: attrs.displayShipDates },
       ],
@@ -33,13 +32,15 @@ export class ShopifyStorefrontCart implements Cart<ShopifyStorefrontCartItem> {
   removePreorderAttributes(item: ShopifyStorefrontCartItem) {
     return {
       ...item,
-      attributes: item.attributes.filter(
+      attributes: item.attributes?.filter(
         ({ key }) => key !== "__releaseId" && key !== "Purple Dot Pre-order",
       ),
     };
   }
 
-  async fetchItems(cartId?: string): Promise<ShopifyStorefrontCartItem[]> {
+  async fetchItems(
+    cartId?: string,
+  ): Promise<Required<ShopifyStorefrontCartItem>[]> {
     const body = await this.graphql({
       query: `query cart($cartId: ID!) {
         cart(id: $cartId) {

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1,0 +1,24 @@
+import { describe, test } from "vitest";
+
+import { init } from "../src/index";
+import { ShopifyAJAXCart } from "../src/shopify-ajax-cart";
+import { ShopifyStorefrontCart } from "../src/shopify-storefront-cart";
+
+describe("passing cartAdapter to init()", () => {
+  test("can initialise it with a ShopifyAJACCart", () => {
+    init({
+      apiKey: "123",
+      cartAdapter: new ShopifyAJAXCart(),
+    });
+  });
+
+  test("can initialise it with a ShopifyStorefrontCart", () => {
+    init({
+      apiKey: "123",
+      cartAdapter: new ShopifyStorefrontCart(
+        "test-store.myshopify.com",
+        "shpat_1234",
+      ),
+    });
+  });
+});

--- a/tests/interceptors.test.ts
+++ b/tests/interceptors.test.ts
@@ -6,7 +6,8 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { FetchParams, RequestInterceptor } from "../src/interceptors";
 
 describe("fetch", () => {
-  let fetchSpy;
+  // rome-ignore lint/suspicious/noExplicitAny: tests
+  let fetchSpy: any;
 
   const handler = vi.fn((request: FetchParams) => Promise.resolve(request));
 

--- a/tests/shopify-cart-interceptors.test.ts
+++ b/tests/shopify-cart-interceptors.test.ts
@@ -8,7 +8,8 @@ const jsonHeader = { "Content-Type": "application/json" };
 const formHeader = { "Content-Type": "application/x-www-form-urlencoded" };
 
 describe("ShopifyAddToCartInterceptor", () => {
-  let fetchSpy;
+  // rome-ignore lint/suspicious/noExplicitAny: tests
+  let fetchSpy: any;
 
   beforeEach(() => {
     window.fetch = fetchSpy = vi.fn(() => Promise.resolve(new Response()));
@@ -44,7 +45,7 @@ describe("ShopifyAddToCartInterceptor", () => {
     });
 
     test("on preorder", async () => {
-      fetchSpy.mockImplementation(async (input: string, init) => {
+      fetchSpy.mockImplementation(async (input: string) => {
         if (input.endsWith("/api/v1/variants/preorder-state?variant_id=1")) {
           return new Response(
             JSON.stringify({
@@ -92,7 +93,7 @@ describe("ShopifyAddToCartInterceptor", () => {
     });
 
     test("single item add on preorder", async () => {
-      fetchSpy.mockImplementation(async (input: string, init) => {
+      fetchSpy.mockImplementation(async (input: string) => {
         if (input.endsWith("/api/v1/variants/preorder-state?variant_id=1")) {
           return new Response(
             JSON.stringify({

--- a/tests/shopify-cart.test.ts
+++ b/tests/shopify-cart.test.ts
@@ -1,26 +1,32 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { ShopifyAJAXCart } from "../src/shopify-ajax-cart";
+
+const shopifyAJAXCart = new ShopifyAJAXCart();
 
 describe("fetch", () => {
   describe("hasPreorderAttributes", () => {
     test("returns true if the item has a __releaseId property", () => {
-      const item = { variantId: "1", properties: { __releaseId: "123" } };
-      expect(ShopifyAJAXCart.hasPreorderAttributes(item)).toBe(true);
+      const item = {
+        id: "1",
+        variantId: "1",
+        properties: { __releaseId: "123" },
+      };
+      expect(shopifyAJAXCart.hasPreorderAttributes(item)).toBe(true);
     });
 
     test("returns false if the item does not have a __releaseId property", () => {
-      const item = { variantId: "1", properties: { foo: "bar" } };
-      expect(ShopifyAJAXCart.hasPreorderAttributes(item)).toBe(false);
+      const item = { id: "1", variantId: "1", properties: { foo: "bar" } };
+      expect(shopifyAJAXCart.hasPreorderAttributes(item)).toBe(false);
     });
   });
 
   describe("addPreorderAttributes", () => {
     test("adds attributes to the item properties", () => {
-      const item = { variantId: "1", properties: { foo: "bar" } };
+      const item = { id: "1", variantId: "1", properties: { foo: "bar" } };
       const attributes = { releaseId: "123", displayShipDates: "tomorrow" };
 
-      const newItem = ShopifyAJAXCart.addPreorderAttributes(item, attributes);
+      const newItem = shopifyAJAXCart.addPreorderAttributes(item, attributes);
 
       expect(newItem.properties).toEqual({
         foo: "bar",
@@ -33,6 +39,7 @@ describe("fetch", () => {
   describe("removePreorderAttributes", () => {
     test("adds attributes to the item properties", () => {
       const item = {
+        id: "1",
         variantId: "1",
         properties: {
           foo: "bar",
@@ -41,7 +48,7 @@ describe("fetch", () => {
         },
       };
 
-      const newItem = ShopifyAJAXCart.removePreorderAttributes(item);
+      const newItem = shopifyAJAXCart.removePreorderAttributes(item);
 
       expect(newItem.properties).toEqual({
         foo: "bar",

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/types.d.ts",
+    "tests/"
+  ]
+}


### PR DESCRIPTION
Since the `ShopifyStorefrontCart` requires a constructor, I wanted to align the `ShopifyAJAXCart` to have the same interface and be a class.

I also did some work to type check tests and make sure everything type checks correctly.