### PR TITLE
feat: new availability API

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "vitest": "^0.33.0",
     "webpack": "^5.88.2",
     "webpack-cli": "^5.1.4",
-    "whatwg-fetch": "^3.6.2"
+    "whatwg-fetch": "^3.6.2",
+    "vitest-fetch-mock": "^0.4.5"
   },
   "packageManager": "pnpm@10.12.4",
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       vitest:
         specifier: ^0.33.0
         version: 0.33.0(happy-dom@15.11.7)(jsdom@22.1.0)(terser@5.43.1)
+      vitest-fetch-mock:
+        specifier: ^0.4.5
+        version: 0.4.5(vitest@0.33.0(happy-dom@15.11.7)(jsdom@22.1.0)(terser@5.43.1))
       webpack:
         specifier: ^5.88.2
         version: 5.99.9(webpack-cli@5.1.4)
@@ -2039,6 +2042,12 @@ packages:
         optional: true
       terser:
         optional: true
+
+  vitest-fetch-mock@0.4.5:
+    resolution: {integrity: sha512-nhWdCQIGtaSEUVl96pMm0WggyDGPDv5FUy/Q9Hx3cs2RGmh3Q/uRsLClGbdG3kXBkJ3br5yTUjB2MeW25TwdOA==, tarball: https://registry.npmjs.org/vitest-fetch-mock/-/vitest-fetch-mock-0.4.5.tgz}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      vitest: '>=2.0.0'
 
   vitest@0.33.0:
     resolution: {integrity: sha512-1CxaugJ50xskkQ0e969R/hW47za4YXDUfWJDxip1hwbnhUjYolpfUn2AMOulqG/Dtd9WYAtkHmM/m3yKVrEejQ==, tarball: https://registry.npmjs.org/vitest/-/vitest-0.33.0.tgz}
@@ -4215,6 +4224,10 @@ snapshots:
       '@types/node': 24.0.4
       fsevents: 2.3.3
       terser: 5.43.1
+
+  vitest-fetch-mock@0.4.5(vitest@0.33.0(happy-dom@15.11.7)(jsdom@22.1.0)(terser@5.43.1)):
+    dependencies:
+      vitest: 0.33.0(happy-dom@15.11.7)(jsdom@22.1.0)(terser@5.43.1)
 
   vitest@0.33.0(happy-dom@15.11.7)(jsdom@22.1.0)(terser@5.43.1):
     dependencies:

--- a/src/availability.ts
+++ b/src/availability.ts
@@ -1,0 +1,102 @@
+import {
+	fetchProductsPreorderState,
+	fetchVariantsPreorderState,
+	type ProductPreorderState,
+} from "./api";
+import { getConfig } from "./config";
+
+/**
+ * Returns the availability of a product or variant.
+ *
+ * Use this when rendering buttons on PDPs etc to decide what the correct behavior is for an item.
+ *
+ * @param request The product or variant to check the availability of.
+ * @param inStockCallback A callback to check if the product is in stock.
+ * @returns The in stock/preorder/out of stock state of the product or variant.
+ */
+export async function availability<I>(
+	request: { variantId: string } | { productHandle: string },
+	inStockCallback?: (
+		request: { variantId: string } | { productHandle: string },
+		getPreorderState: () => Promise<PurpleDotAvailability | null>,
+	) => Promise<I | false>,
+): Promise<PurpleDotAvailability<I>> {
+	const config = getConfig();
+
+	// Don't immediately fetch the preorder state, as it may not be needed.
+
+	let preorderStatePromise: Promise<PurpleDotAvailability | null> | undefined;
+	const getPreorderState = () => {
+		if (!preorderStatePromise) {
+			const fetchPromise =
+				"variantId" in request
+					? fetchVariantsPreorderState(request.variantId)
+					: fetchProductsPreorderState(request.productHandle);
+
+			preorderStatePromise = fetchPromise.then((state) =>
+				mapPreorderStateToAvailability(state),
+			);
+		}
+
+		return preorderStatePromise;
+	};
+
+	const thisInStockCallback = inStockCallback ?? config?.inStockAvailability;
+
+	const inStockAvailable = thisInStockCallback
+		? await thisInStockCallback(request, getPreorderState)
+		: false;
+
+	if (inStockAvailable) {
+		return { state: "AVAILABLE_IN_STOCK", available: inStockAvailable };
+	}
+
+	const state = await getPreorderState();
+	return state ?? { state: "SOLD_OUT" };
+}
+
+export interface PurpleDotOnPreorder {
+	state: "ON_PREORDER";
+	waitlist: {
+		id: string;
+		selling_plan_id?: string;
+		display_dispatch_date: string;
+		units_left: number;
+	};
+}
+
+export interface PurpleDotAvailableInStock<I> {
+	state: "AVAILABLE_IN_STOCK";
+	available?: I;
+}
+
+export interface PurpleDotSoldOut {
+	state: "SOLD_OUT";
+}
+
+export type PurpleDotAvailability<I = any> =
+	| PurpleDotOnPreorder
+	| PurpleDotAvailableInStock<I>
+	| PurpleDotSoldOut;
+
+function mapPreorderStateToAvailability(
+	preorderState: ProductPreorderState | null,
+): PurpleDotAvailability | null {
+	if (preorderState?.state === "ON_PREORDER" && preorderState.waitlist) {
+		return {
+			state: "ON_PREORDER",
+			waitlist: {
+				id: preorderState.waitlist.id,
+				selling_plan_id: preorderState.waitlist.selling_plan_id ?? undefined,
+				display_dispatch_date: preorderState.waitlist.display_dispatch_date,
+				units_left: preorderState.waitlist.units_left,
+			},
+		};
+	} else if (preorderState?.state === "AVAILABLE_IN_STOCK") {
+		return { state: "AVAILABLE_IN_STOCK" };
+	} else if (preorderState?.state === "SOLD_OUT") {
+		return { state: "SOLD_OUT" };
+	} else {
+		return null;
+	}
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,18 +1,36 @@
+import type { PurpleDotAvailability } from "./availability";
 import type { Cart, CartItem } from "./cart";
 
+/**
+ * Global Purple Dot configuration.
+ */
 export interface PurpleDotConfig {
+	/**
+	 * The Purple Dot API key for the store.
+	 */
 	apiKey: string;
-	cartAdapter: Cart<CartItem>;
-}
 
+	/**
+	 * Optional cart adapter for working with the combined checkout.
+	 */
+	cartAdapter?: Cart<CartItem>;
+
+	/**
+	 * Optional default hook for checking the in stock availability of a product.
+	 */
+	inStockAvailability?: <I>(
+		request: { variantId: string } | { productHandle: string },
+		getPreorderState: () => Promise<PurpleDotAvailability | null>,
+	) => Promise<I | false>;
+}
 let config: PurpleDotConfig | null = null;
 
-export function setConfig(c: PurpleDotConfig) {
-	config = c;
+export function setConfig(newConfig: PurpleDotConfig) {
+	config = newConfig;
 
 	// For compatibility with checkout.js script that reads the config from window
 	if (globalThis.window) {
-		globalThis.window.PurpleDotConfig = c;
+		globalThis.window.PurpleDotConfig = newConfig;
 	}
 }
 

--- a/src/shopify-in-stock-availability.ts
+++ b/src/shopify-in-stock-availability.ts
@@ -1,9 +1,10 @@
 import type { ProductPreorderState } from "./api";
 
 export async function shopifyInStockAvailability(
-	preorderStatePromise: Promise<ProductPreorderState>,
+	_request: { variantId: string } | { productHandle: string },
+	getPreorderState: () => Promise<ProductPreorderState>,
 ) {
-	const preorderState = await preorderStatePromise;
+	const preorderState = await getPreorderState();
 
 	return preorderState.state === "AVAILABLE_IN_STOCK";
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,11 +1,8 @@
-import type { Cart, CartItem } from "./cart";
+import { PurpleDotConfig } from "./config";
 
-export declare global {
+declare global {
 	interface Window {
-		PurpleDotConfig?: {
-			apiKey: string;
-			cartAdapter: Cart<CartItem>;
-		};
+		PurpleDotConfig?: PurpleDotConfig;
 
 		Shopify?: {
 			shop?: string;

--- a/tests/availability.test.ts
+++ b/tests/availability.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import createFetchMock from "vitest-fetch-mock";
+import { init } from "../src";
+import { availability } from "../src/availability";
+
+const fetchMocker = createFetchMock(vi);
+fetchMocker.enableMocks();
+
+beforeEach(() => {
+	init({
+		apiKey: "123",
+	});
+});
+
+describe("availability", () => {
+	describe("when the product is in stock", () => {
+		it("should return AVAILABLE_IN_STOCK", async () => {
+			const state = await availability({ variantId: "123" }, () =>
+				Promise.resolve(true),
+			);
+			expect(state).toEqual({ state: "AVAILABLE_IN_STOCK", available: true });
+		});
+	});
+
+	describe("when the product is sold out", () => {
+		beforeEach(() => {
+			fetchMocker.mockResponse(
+				JSON.stringify({
+					data: {
+						state: "SOLD_OUT",
+					},
+				}),
+			);
+		});
+
+		it("should return SOLD_OUT", async () => {
+			const state = await availability({ variantId: "123" }, () =>
+				Promise.resolve(false),
+			);
+			expect(state).toEqual({ state: "SOLD_OUT" });
+		});
+	});
+
+	describe("when the product is on preorder", () => {
+		beforeEach(() => {
+			fetchMocker.mockResponse(
+				JSON.stringify({
+					data: {
+						state: "ON_PREORDER",
+						waitlist: {
+							id: "123",
+							selling_plan_id: "456",
+							display_dispatch_date: "2025-01-01",
+							units_left: 10,
+						},
+					},
+				}),
+			);
+		});
+
+		it("should return ON_PREORDER", async () => {
+			const state = await availability({ variantId: "123" }, () =>
+				Promise.resolve(false),
+			);
+			expect(state).toEqual({
+				state: "ON_PREORDER",
+				waitlist: {
+					id: "123",
+					selling_plan_id: "456",
+					display_dispatch_date: "2025-01-01",
+					units_left: 10,
+				},
+			});
+		});
+	});
+});


### PR DESCRIPTION
New API for availability in the browser SDK.

The current "preorder-state" API has some issues when working with brands like SFCC where we don't keep track of their non-preorder inventory. Specifically it will *never* return the correct state of IN STOCK. This is not a huge problem, Kendra for example have managed to mostly work around this themselves but it definitely made things more confusing for them and I had to point them in the right direction a bit.

This approach allows us to provide a consistent availability API regardless of whether we have PD-side tracking of in stock inventory and also allows us to encourage the merchant gently to not call PD unless they actually need to. We achieve this by adding a hook which allows the merchant to inject their own in stock availability data whenever checking the preorder state.

```ts
init({
  inStockAvailability: ({ variantId }) => fetch(`/kendras-products?variant=${variant}`).json().available === true
});

function MyButton({variantId: string}) {
  const [availability, setAvailability] = useState();
  
  useEffect(async () => {
    availability({ variantId }).then((a) => setAvailability(a));   
  }, [variantId]);

  // Render the correct state for the button.
}

```