### PR TITLE
fix: handle cases where our API is incorrect about the in stock state better

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@purple-dot/browser",
   "description": "Purple Dot Browser SDK",
   "license": "Apache-2.0",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "scripts": {
     "build": "tsc",
     "prepare": "tsc",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@purple-dot/browser",
   "description": "Purple Dot Browser SDK",
   "license": "Apache-2.0",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "build": "tsc",
     "prepare": "tsc",

--- a/src/availability.ts
+++ b/src/availability.ts
@@ -1,15 +1,15 @@
 import {
-  fetchProductsPreorderState,
-  fetchVariantsPreorderState,
-  type ProductPreorderState,
+	fetchProductsPreorderState,
+	fetchVariantsPreorderState,
+	type ProductPreorderState,
 } from "./api";
 import { getConfig } from "./config";
 
 type AvailabilityRequest<J> = J extends
-  | { variantId: string }
-  | { productHandle: string }
-  ? J
-  : never;
+	| { variantId: string }
+	| { productHandle: string }
+	? J
+	: never;
 
 /**
  * Returns the availability of a product or variant.
@@ -21,119 +21,119 @@ type AvailabilityRequest<J> = J extends
  * @returns The in stock/preorder/out of stock state of the product or variant.
  */
 export async function availability<I, J>(
-  request: AvailabilityRequest<J>,
-  inStockCallback?: (
-    request: AvailabilityRequest<J>,
-    getPreorderState: () => Promise<PurpleDotAvailability | null>,
-  ) => Promise<I | false>,
+	request: AvailabilityRequest<J>,
+	inStockCallback?: (
+		request: AvailabilityRequest<J>,
+		getPreorderState: () => Promise<PurpleDotAvailability | null>,
+	) => Promise<I | false>,
 ): Promise<PurpleDotAvailability<I>> {
-  const config = getConfig();
+	const config = getConfig();
 
-  // Don't immediately fetch the preorder state, as it may not be needed.
+	// Don't immediately fetch the preorder state, as it may not be needed.
 
-  let preorderStatePromise: Promise<PurpleDotAvailability | null> | undefined;
-  const getPreorderState = () => {
-    if (!preorderStatePromise) {
-      const fetchPromise =
-        "variantId" in request
-          ? fetchVariantsPreorderState(request.variantId)
-          : fetchProductsPreorderState(request.productHandle);
+	let preorderStatePromise: Promise<PurpleDotAvailability | null> | undefined;
+	const getPreorderState = () => {
+		if (!preorderStatePromise) {
+			const fetchPromise =
+				"variantId" in request
+					? fetchVariantsPreorderState(request.variantId)
+					: fetchProductsPreorderState(request.productHandle);
 
-      preorderStatePromise = fetchPromise.then((state) =>
-        mapPreorderStateToAvailability(state),
-      );
-    }
+			preorderStatePromise = fetchPromise.then((state) =>
+				mapPreorderStateToAvailability(state),
+			);
+		}
 
-    return preorderStatePromise;
-  };
+		return preorderStatePromise;
+	};
 
-  const thisInStockCallback = inStockCallback ?? config?.inStockAvailability;
+	const thisInStockCallback = inStockCallback ?? config?.inStockAvailability;
 
-  const inStockAvailable = thisInStockCallback
-    ? await thisInStockCallback(request, getPreorderState)
-    : false;
+	const inStockAvailable = thisInStockCallback
+		? await thisInStockCallback(request, getPreorderState)
+		: false;
 
-  if (inStockAvailable) {
-    return { state: "AVAILABLE_IN_STOCK", available: inStockAvailable };
-  }
+	if (inStockAvailable) {
+		return { state: "AVAILABLE_IN_STOCK", available: inStockAvailable };
+	}
 
-  const state = await getPreorderState();
+	const state = await getPreorderState();
 
-  if (state?.state === "SOLD_OUT") {
-    return { state: "SOLD_OUT" };
-  }
+	if (state?.state === "SOLD_OUT") {
+		return { state: "SOLD_OUT" };
+	}
 
-  // At this point we know that it should not be considered in stock, so remap it to a waitlist if there is one.
+	// At this point we know that it should not be considered in stock, so remap it to a waitlist if there is one.
 
-  if (state?.waitlist) {
-    return { state: "ON_PREORDER", waitlist: state.waitlist };
-  }
+	if (state?.waitlist) {
+		return { state: "ON_PREORDER", waitlist: state.waitlist };
+	}
 
-  return { state: "SOLD_OUT" };
+	return { state: "SOLD_OUT" };
 }
 
 interface PurpleDotWaitlist {
-  id: string;
-  selling_plan_id?: string;
-  display_dispatch_date: string;
-  units_left: number;
-  compatible_checkouts: ("purple_dot" | "native")[];
+	id: string;
+	selling_plan_id?: string;
+	display_dispatch_date: string;
+	units_left: number;
+	compatible_checkouts: ("purple_dot" | "native")[];
 }
 
 export interface PurpleDotOnPreorder {
-  state: "ON_PREORDER";
-  waitlist: PurpleDotWaitlist;
+	state: "ON_PREORDER";
+	waitlist: PurpleDotWaitlist;
 }
 
 export interface PurpleDotAvailableInStock<I> {
-  state: "AVAILABLE_IN_STOCK";
-  available?: I;
-  waitlist?: PurpleDotWaitlist;
+	state: "AVAILABLE_IN_STOCK";
+	available?: I;
+	waitlist?: PurpleDotWaitlist;
 }
 
 export interface PurpleDotSoldOut {
-  state: "SOLD_OUT";
+	state: "SOLD_OUT";
 }
 
 export type PurpleDotAvailability<I = any> =
-  | PurpleDotOnPreorder
-  | PurpleDotAvailableInStock<I>
-  | PurpleDotSoldOut;
+	| PurpleDotOnPreorder
+	| PurpleDotAvailableInStock<I>
+	| PurpleDotSoldOut;
 
 function mapPreorderStateToAvailability(
-  preorderState: ProductPreorderState | null,
+	preorderState: ProductPreorderState | null,
 ): PurpleDotAvailability | null {
-  if (preorderState?.state === "ON_PREORDER" && preorderState.waitlist) {
-    return {
-      state: "ON_PREORDER",
-      waitlist: mapWaitlist(preorderState.waitlist),
-    };
-  } else if (preorderState?.state === "AVAILABLE_IN_STOCK") {
-    return {
-      state: "AVAILABLE_IN_STOCK",
-      waitlist: mapWaitlist(preorderState.waitlist),
-    };
-  } else if (preorderState?.state === "SOLD_OUT") {
-    return { state: "SOLD_OUT" };
-  } else {
-    return null;
-  }
+	if (preorderState?.state === "ON_PREORDER" && preorderState.waitlist) {
+		return {
+			state: "ON_PREORDER",
+			waitlist: mapWaitlist(preorderState.waitlist),
+		};
+	} else if (preorderState?.state === "AVAILABLE_IN_STOCK") {
+		return {
+			state: "AVAILABLE_IN_STOCK",
+			waitlist: mapWaitlist(preorderState.waitlist),
+		};
+	} else if (preorderState?.state === "SOLD_OUT") {
+		return { state: "SOLD_OUT" };
+	} else {
+		return null;
+	}
 }
 
 function mapWaitlist<
-  T extends ProductPreorderState["waitlist"] | undefined | null,
+	T extends ProductPreorderState["waitlist"] | undefined | null,
 >(waitlist: T): T extends null | undefined ? undefined : PurpleDotWaitlist {
-  if (!waitlist) {
-    return undefined as T extends null | undefined
-      ? undefined
-      : PurpleDotWaitlist;
-  }
+	if (!waitlist) {
+		return undefined as T extends null | undefined
+			? undefined
+			: PurpleDotWaitlist;
+	}
 
-  return {
-    id: waitlist.id,
-    selling_plan_id: waitlist.selling_plan_id ?? undefined,
-    display_dispatch_date: waitlist.display_dispatch_date,
-    units_left: waitlist.units_left,
-    compatible_checkouts: waitlist.compatible_checkouts,
-  } as T extends null | undefined ? undefined : PurpleDotWaitlist;
+	return {
+		id: waitlist.id,
+		selling_plan_id: waitlist.selling_plan_id ?? undefined,
+		display_dispatch_date: waitlist.display_dispatch_date,
+		units_left: waitlist.units_left,
+		compatible_checkouts: waitlist.compatible_checkouts,
+	} as T extends null | undefined ? undefined : PurpleDotWaitlist;
 }

--- a/src/availability.ts
+++ b/src/availability.ts
@@ -1,15 +1,15 @@
 import {
-	fetchProductsPreorderState,
-	fetchVariantsPreorderState,
-	type ProductPreorderState,
+  fetchProductsPreorderState,
+  fetchVariantsPreorderState,
+  type ProductPreorderState,
 } from "./api";
 import { getConfig } from "./config";
 
 type AvailabilityRequest<J> = J extends
-	| { variantId: string }
-	| { productHandle: string }
-	? J
-	: never;
+  | { variantId: string }
+  | { productHandle: string }
+  ? J
+  : never;
 
 /**
  * Returns the availability of a product or variant.
@@ -21,90 +21,119 @@ type AvailabilityRequest<J> = J extends
  * @returns The in stock/preorder/out of stock state of the product or variant.
  */
 export async function availability<I, J>(
-	request: AvailabilityRequest<J>,
-	inStockCallback?: (
-		request: AvailabilityRequest<J>,
-		getPreorderState: () => Promise<PurpleDotAvailability | null>,
-	) => Promise<I | false>,
+  request: AvailabilityRequest<J>,
+  inStockCallback?: (
+    request: AvailabilityRequest<J>,
+    getPreorderState: () => Promise<PurpleDotAvailability | null>,
+  ) => Promise<I | false>,
 ): Promise<PurpleDotAvailability<I>> {
-	const config = getConfig();
+  const config = getConfig();
 
-	// Don't immediately fetch the preorder state, as it may not be needed.
+  // Don't immediately fetch the preorder state, as it may not be needed.
 
-	let preorderStatePromise: Promise<PurpleDotAvailability | null> | undefined;
-	const getPreorderState = () => {
-		if (!preorderStatePromise) {
-			const fetchPromise =
-				"variantId" in request
-					? fetchVariantsPreorderState(request.variantId)
-					: fetchProductsPreorderState(request.productHandle);
+  let preorderStatePromise: Promise<PurpleDotAvailability | null> | undefined;
+  const getPreorderState = () => {
+    if (!preorderStatePromise) {
+      const fetchPromise =
+        "variantId" in request
+          ? fetchVariantsPreorderState(request.variantId)
+          : fetchProductsPreorderState(request.productHandle);
 
-			preorderStatePromise = fetchPromise.then((state) =>
-				mapPreorderStateToAvailability(state),
-			);
-		}
+      preorderStatePromise = fetchPromise.then((state) =>
+        mapPreorderStateToAvailability(state),
+      );
+    }
 
-		return preorderStatePromise;
-	};
+    return preorderStatePromise;
+  };
 
-	const thisInStockCallback = inStockCallback ?? config?.inStockAvailability;
+  const thisInStockCallback = inStockCallback ?? config?.inStockAvailability;
 
-	const inStockAvailable = thisInStockCallback
-		? await thisInStockCallback(request, getPreorderState)
-		: false;
+  const inStockAvailable = thisInStockCallback
+    ? await thisInStockCallback(request, getPreorderState)
+    : false;
 
-	if (inStockAvailable) {
-		return { state: "AVAILABLE_IN_STOCK", available: inStockAvailable };
-	}
+  if (inStockAvailable) {
+    return { state: "AVAILABLE_IN_STOCK", available: inStockAvailable };
+  }
 
-	const state = await getPreorderState();
-	return state ?? { state: "SOLD_OUT" };
+  const state = await getPreorderState();
+
+  if (state?.state === "SOLD_OUT") {
+    return { state: "SOLD_OUT" };
+  }
+
+  // At this point we know that it should not be considered in stock, so remap it to a waitlist if there is one.
+
+  if (state?.waitlist) {
+    return { state: "ON_PREORDER", waitlist: state.waitlist };
+  }
+
+  return { state: "SOLD_OUT" };
+}
+
+interface PurpleDotWaitlist {
+  id: string;
+  selling_plan_id?: string;
+  display_dispatch_date: string;
+  units_left: number;
+  compatible_checkouts: ("purple_dot" | "native")[];
 }
 
 export interface PurpleDotOnPreorder {
-	state: "ON_PREORDER";
-	waitlist: {
-		id: string;
-		selling_plan_id?: string;
-		display_dispatch_date: string;
-		units_left: number;
-		compatible_checkouts: ("purple_dot" | "native")[];
-	};
+  state: "ON_PREORDER";
+  waitlist: PurpleDotWaitlist;
 }
 
 export interface PurpleDotAvailableInStock<I> {
-	state: "AVAILABLE_IN_STOCK";
-	available?: I;
+  state: "AVAILABLE_IN_STOCK";
+  available?: I;
+  waitlist?: PurpleDotWaitlist;
 }
 
 export interface PurpleDotSoldOut {
-	state: "SOLD_OUT";
+  state: "SOLD_OUT";
 }
 
 export type PurpleDotAvailability<I = any> =
-	| PurpleDotOnPreorder
-	| PurpleDotAvailableInStock<I>
-	| PurpleDotSoldOut;
+  | PurpleDotOnPreorder
+  | PurpleDotAvailableInStock<I>
+  | PurpleDotSoldOut;
 
 function mapPreorderStateToAvailability(
-	preorderState: ProductPreorderState | null,
+  preorderState: ProductPreorderState | null,
 ): PurpleDotAvailability | null {
-	if (preorderState?.state === "ON_PREORDER" && preorderState.waitlist) {
-		return {
-			state: "ON_PREORDER",
-			waitlist: {
-				id: preorderState.waitlist.id,
-				selling_plan_id: preorderState.waitlist.selling_plan_id ?? undefined,
-				display_dispatch_date: preorderState.waitlist.display_dispatch_date,
-				units_left: preorderState.waitlist.units_left,
-				compatible_checkouts: preorderState.waitlist.compatible_checkouts,
-			},
-		};
-	} else if (preorderState?.state === "AVAILABLE_IN_STOCK") {
-		return { state: "AVAILABLE_IN_STOCK" };
-	} else if (preorderState?.state === "SOLD_OUT") {
-		return { state: "SOLD_OUT" };
-	} else {
-		return null;
-	}
+  if (preorderState?.state === "ON_PREORDER" && preorderState.waitlist) {
+    return {
+      state: "ON_PREORDER",
+      waitlist: mapWaitlist(preorderState.waitlist),
+    };
+  } else if (preorderState?.state === "AVAILABLE_IN_STOCK") {
+    return {
+      state: "AVAILABLE_IN_STOCK",
+      waitlist: mapWaitlist(preorderState.waitlist),
+    };
+  } else if (preorderState?.state === "SOLD_OUT") {
+    return { state: "SOLD_OUT" };
+  } else {
+    return null;
+  }
+}
+
+function mapWaitlist<
+  T extends ProductPreorderState["waitlist"] | undefined | null,
+>(waitlist: T): T extends null | undefined ? undefined : PurpleDotWaitlist {
+  if (!waitlist) {
+    return undefined as T extends null | undefined
+      ? undefined
+      : PurpleDotWaitlist;
+  }
+
+  return {
+    id: waitlist.id,
+    selling_plan_id: waitlist.selling_plan_id ?? undefined,
+    display_dispatch_date: waitlist.display_dispatch_date,
+    units_left: waitlist.units_left,
+    compatible_checkouts: waitlist.compatible_checkouts,
+  } as T extends null | undefined ? undefined : PurpleDotWaitlist;
 }

--- a/tests/availability.test.ts
+++ b/tests/availability.test.ts
@@ -73,4 +73,37 @@ describe("availability", () => {
 			});
 		});
 	});
+
+	describe("when the product is not in stock but our api says that it is", () => {
+		beforeEach(() => {
+			fetchMocker.mockResponse(
+				JSON.stringify({
+					data: {
+						state: "AVAILABLE_IN_STOCK",
+						waitlist: {
+							id: "123",
+							selling_plan_id: "456",
+							display_dispatch_date: "2025-01-01",
+							units_left: 10,
+						},
+					},
+				}),
+			);
+		});
+
+		it("should return ON_PREORDER", async () => {
+			const state = await availability({ variantId: "123" }, () =>
+				Promise.resolve(false),
+			);
+			expect(state).toEqual({
+				state: "ON_PREORDER",
+				waitlist: {
+					id: "123",
+					selling_plan_id: "456",
+					display_dispatch_date: "2025-01-01",
+					units_left: 10,
+				},
+			});
+		});
+	});
 });


### PR DESCRIPTION
Currently for cases where our API is wrong about the in stock state (e.g. SFCC) we will return in stock incorrectly. This fix allows the custom callback to override our API and return ON_PREORDER for these items correctly.