### PR TITLE
feat: detect if separate checkout required from cart attributes

### DIFF
--- a/src/cart.ts
+++ b/src/cart.ts
@@ -14,6 +14,7 @@ export interface CartItem {
 	id: string;
 	variantId: string | null;
 	quantity: number;
+	attributes: { key: string; value: string }[];
 }
 
 export interface Cart<T extends CartItem> {
@@ -44,4 +45,38 @@ export function getCartAdapter(): Cart<CartItem> {
 		throw new Error("@purple-dot/browser not initialised");
 	}
 	return cart;
+}
+
+export function purpleDotAttributes(variant: {
+	isPreorder: boolean;
+	releaseId?: string | null;
+	sellingPlanId?: string | null;
+	compatibleCheckouts?: string[];
+	estimatedShipDates?: string | null;
+}): { key: string; value: string }[] {
+	if (!variant.isPreorder) {
+		return [];
+	}
+
+	const attributes = [];
+
+	if (variant.releaseId) {
+		attributes.push({ key: "__releaseId", value: variant.releaseId });
+	}
+
+	if (!variant.sellingPlanId && variant.estimatedShipDates) {
+		attributes.push({
+			key: "Purple Dot Pre-order",
+			value: variant.estimatedShipDates,
+		});
+	}
+
+	if (variant.compatibleCheckouts) {
+		attributes.push({
+			key: "__pdCheckoutRequired",
+			value: variant.compatibleCheckouts.includes("native") ? "false" : "true",
+		});
+	}
+
+	return attributes;
 }

--- a/src/checkout.ts
+++ b/src/checkout.ts
@@ -115,6 +115,13 @@ async function cartRequiresSeparateCheckout(cartItems: CartItem[]) {
 
 async function cartItemRequiresSeparateCheckout(cartItem: CartItem) {
 	if (cartItem.variantId) {
+		const requiredAttr = cartItem.attributes.find(
+			({ key }) => key === "__pdCheckoutRequired",
+		);
+		if (requiredAttr) {
+			return requiredAttr.value === "true";
+		}
+
 		const res = await fetchVariantsPreorderState(idFromGid(cartItem.variantId));
 		if (
 			res &&

--- a/src/shopify-ajax-cart-interceptors.ts
+++ b/src/shopify-ajax-cart-interceptors.ts
@@ -138,6 +138,7 @@ function getItemsFromRequest(
 					id: item.id,
 					variantId: `${item.id}`,
 					properties: item.properties,
+					attributes: item.attributes,
 					quantity:
 						item.quantity || item.quantity === 0
 							? parseFloat(item.quantity)
@@ -168,6 +169,10 @@ function getItemsFromRequest(
 			variantId,
 			quantity,
 			properties,
+			attributes: Object.entries(properties ?? {}).map(([key, value]) => ({
+				key,
+				value,
+			})),
 		},
 	];
 

--- a/src/shopify-ajax-cart.ts
+++ b/src/shopify-ajax-cart.ts
@@ -15,7 +15,7 @@ export class ShopifyAJAXCart implements Cart<ShopifyAJAXCartItem> {
 	}
 
 	addPreorderAttributes(item: ShopifyAJAXCartItem, attrs: PreorderAttributes) {
-		return {
+		return addAttributes({
 			id: item.id,
 			variantId: item.variantId,
 			quantity: item.quantity,
@@ -24,11 +24,11 @@ export class ShopifyAJAXCart implements Cart<ShopifyAJAXCartItem> {
 				__releaseId: attrs.releaseId,
 				"Purple Dot Pre-order": attrs.displayShipDates,
 			},
-		};
+		});
 	}
 
 	removePreorderAttributes(item: ShopifyAJAXCartItem) {
-		return {
+		return addAttributes({
 			id: item.id,
 			variantId: item.variantId,
 			quantity: item.quantity,
@@ -37,7 +37,7 @@ export class ShopifyAJAXCart implements Cart<ShopifyAJAXCartItem> {
 					([key]) => key !== "__releaseId" && key !== "Purple Dot Pre-order",
 				),
 			),
-		};
+		});
 	}
 
 	async fetchItems() {
@@ -125,4 +125,16 @@ export async function updatePreorderAttributes(
 	}
 
 	return null;
+}
+
+export function addAttributes<
+	T extends { properties?: Record<string, string> },
+>(x: T) {
+	return {
+		...x,
+		attributes: Object.entries(x.properties ?? {}).map(([key, value]) => ({
+			key,
+			value,
+		})),
+	};
 }

--- a/src/shopify-storefront-cart.ts
+++ b/src/shopify-storefront-cart.ts
@@ -2,7 +2,6 @@ import type { Cart, CartItem, PreorderAttributes } from "./cart";
 import { idFromGid } from "./gid";
 
 export interface ShopifyStorefrontCartItem extends CartItem {
-	attributes?: { key: string; value: string }[];
 	merchandise?: {
 		id: string;
 	};
@@ -78,6 +77,7 @@ export class ShopifyStorefrontCart implements Cart<ShopifyStorefrontCartItem> {
 			({ node }: { node: any }) => ({
 				...node,
 				variantId: node.merchandise.id,
+				attributes: node.attributes ?? [],
 			}),
 		);
 	}

--- a/tests/shopify-cart.test.ts
+++ b/tests/shopify-cart.test.ts
@@ -1,40 +1,40 @@
 import { describe, expect, test } from "vitest";
 
-import { ShopifyAJAXCart } from "../src/shopify-ajax-cart";
+import { addAttributes, ShopifyAJAXCart } from "../src/shopify-ajax-cart";
 
 const shopifyAJAXCart = new ShopifyAJAXCart();
 
 describe("fetch", () => {
 	describe("hasPreorderAttributes", () => {
 		test("returns true if the item has a __releaseId property", () => {
-			const item = {
+			const item = addAttributes({
 				id: "1",
 				variantId: "1",
 				properties: { __releaseId: "123" },
 				quantity: 1,
-			};
+			});
 			expect(shopifyAJAXCart.hasPreorderAttributes(item)).toBe(true);
 		});
 
 		test("returns false if the item does not have a __releaseId property", () => {
-			const item = {
+			const item = addAttributes({
 				id: "1",
 				variantId: "1",
 				properties: { foo: "bar" },
 				quantity: 1,
-			};
+			});
 			expect(shopifyAJAXCart.hasPreorderAttributes(item)).toBe(false);
 		});
 	});
 
 	describe("addPreorderAttributes", () => {
 		test("adds attributes to the item properties", () => {
-			const item = {
+			const item = addAttributes({
 				id: "1",
 				variantId: "1",
 				properties: { foo: "bar" },
 				quantity: 1,
-			};
+			});
 			const attributes = { releaseId: "123", displayShipDates: "tomorrow" };
 
 			const newItem = shopifyAJAXCart.addPreorderAttributes(item, attributes);
@@ -49,7 +49,7 @@ describe("fetch", () => {
 
 	describe("removePreorderAttributes", () => {
 		test("adds attributes to the item properties", () => {
-			const item = {
+			const item = addAttributes({
 				id: "1",
 				variantId: "1",
 				properties: {
@@ -58,7 +58,7 @@ describe("fetch", () => {
 					"Purple Dot Pre-order": "tomorrow",
 				},
 				quantity: 1,
-			};
+			});
 
 			const newItem = shopifyAJAXCart.removePreorderAttributes(item);
 


### PR DESCRIPTION
This PR adds the ability to check if the cart requires separate checkout based on the `__pdCheckoutRequired` attribute, to avoid having to make a large number of network calls for carts with multiple items.

The attribute will get set by the `purpleDotAttributes()` helper function, which we will encourage the merchants to use. If the attribute is not set, we can fall back to doing a network call.