### PR TITLE
fix(ENG-2743): find cart line item to remove using cart line item id

### DIFF
--- a/src/shopify-storefront-cart.ts
+++ b/src/shopify-storefront-cart.ts
@@ -82,16 +82,25 @@ export class ShopifyStorefrontCart implements Cart<ShopifyStorefrontCartItem> {
 		);
 	}
 
-	async decrementQuantity(variantId: string, cartId?: string | null) {
+	async decrementQuantity(
+		variantIdOrCartLineItemId: string,
+		cartId?: string | null,
+	) {
 		if (!cartId) {
 			throw new Error("cartId must be provided to ShopifyStorefrontCart");
 		}
 
 		const items = await this.fetchItems(cartId);
-		const line = items.find(
-			(item) => idFromGid(item.merchandise.id) === variantId,
-		);
+		const line = items.find((item) => {
+			if (idFromGid(item.merchandise.id) === variantIdOrCartLineItemId) {
+				return true;
+			}
+			return item.id === variantIdOrCartLineItemId;
+		});
 		if (!line) {
+			console.warn(
+				`Could not find line item with id ${variantIdOrCartLineItemId} in cart ${cartId}`,
+			);
 			return;
 		}
 		const quantity = line.quantity - 1;


### PR DESCRIPTION
In [this PR](https://github.com/purple-dot/purple-dot/pull/9948) within the `purple-dot/main` package, we made a change to remove line items using the `externalCartLineItemId`, with a fallback to using the variant ids.

At the time, according to [this comment](https://github.com/purple-dot/purple-dot/pull/9948#discussion_r1704492068) there was an assumption that the cart line item id = variant id, but according to [the docs](https://shopify.dev/docs/api/liquid/objects/line_item#line_item-id) this can vary depending on the context.

Based on tracing through an actual case, we've identified that at least for headless stores, the cart item id is NOT the same as the product variant id.
<img width="890" height="343" alt="CleanShot 2025-07-31 at 08 45 39" src="https://github.com/user-attachments/assets/e9c7b803-a58a-4880-8112-fb497bb76a24" />

This PR makes it so that we also check for a CartLine id match in addition to the ProductVariant id match. It also adds a console warning if we can't find the corresponding line to decrement from the cart, so that we don't just silently fail and return.

I think this is the simplest and safest way to maintain current behavior while fixing the issue.
