### PR TITLE
feat: add .close() method to checkout

### DIFF
--- a/src/checkout.ts
+++ b/src/checkout.ts
@@ -20,6 +20,7 @@ export type PurpleDotAddItemResponse =
 
 export interface PurpleDotCheckoutElement extends Element {
 	open: (args: { cartId: string; cartType: string }) => void;
+	close: () => void;
 	expressCheckout: (args: {
 		variantId: string;
 		releaseId: string;
@@ -37,12 +38,14 @@ export interface PurpleDotCheckoutElement extends Element {
 	show: () => void;
 }
 
+const CHECKOUT_ELEMENT = "purple-dot-checkout";
+
 export async function open(args?: { cartId?: string; sessionId?: string }) {
-	if (document.querySelector("purple-dot-checkout")) {
+	if (document.querySelector(CHECKOUT_ELEMENT)) {
 		return;
 	}
 
-	const element = document.createElement("purple-dot-checkout");
+	const element = document.createElement(CHECKOUT_ELEMENT);
 	document.body.appendChild(element);
 
 	const cartAdapter = getCartAdapter();
@@ -100,10 +103,10 @@ export async function purpleDotCheckout<T>(
 }
 
 function getOrCreateCheckoutElement() {
-	let element = document.querySelector("purple-dot-checkout");
+	let element = document.querySelector(CHECKOUT_ELEMENT);
 
 	if (!element) {
-		element = document.createElement("purple-dot-checkout");
+		element = document.createElement(CHECKOUT_ELEMENT);
 		document.body.appendChild(element);
 	}
 


### PR DESCRIPTION
I tried to add the `.close()` method without having to update this package, but that doesn't seem possible for a few reasons:

* The raw web component is untyped, and requires actively ignoring typescript typescript (we have to do `checkout.close() // @ts-ignore`). I think this is suboptimal, all these headless integrations are in Typescript and we should provide sensible types.
* If we rely on the existing `purpleDotCheckout()` function, the `PurpleDotCheckoutElement` interface still needs updating and a new package version publishing if we add new methods to the web component.
* At that point, might as well add a nicer `checkout.close()` method to the module, so it's symmetrical with `checkout.open()` that's already export.
* Also `purpleDotCheckout()` seems to create the element if it doesn't exist, which I'm not sure is desirable in this case. Calling `close()` when the element doesn't exist should be a simple no-op.